### PR TITLE
Route parametre avec france connect actif ou pas

### DIFF
--- a/back-end/index.js
+++ b/back-end/index.js
@@ -58,6 +58,7 @@ const pdf           = require('./routes/pdf');
 const user          = require('./routes/user');
 const documents     = require('./routes/documents');
 const batch         = require('./routes/batch');
+const parametres         = require('./routes/parametres');
 const exp         = require('./routes/export');
 const demandeaaq         = require('./routes/demandeaaq');
 
@@ -94,6 +95,8 @@ app.get(config.URL_PREFIX + '', function (req, res) {
 });
 
 app.use(config.URL_PREFIX + '/batch', batch);
+
+app.use(config.URL_PREFIX + '/parametres', parametres);
 
 app.use(config.URL_PREFIX + '/export', exp);
 

--- a/back-end/routes/parametres.js
+++ b/back-end/routes/parametres.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const router = express.Router();
+
+const logger = require('../utils/logger')
+const log = logger(module.filename)
+
+const pgPool = require('../pgpool').getPool();
+const config     = require('../config');
+var moment = require('moment');
+
+// Route permettant de savoir si la clé CLIENT_ID France connect est renseignée ou existante
+// Si elle ne l'est pas, alors on n'affiche pas les infos de connexion France Connect
+router.get('/fcactif', (req, res) => {
+    log.i('IN::parametre  France Connect')
+    log.d(config.franceConnect.CLIENT_ID)
+    if (config.franceConnect.CLIENT_ID && config.franceConnect.CLIENT_ID!="") 
+    {
+        res.send(true);
+    }
+    else
+    {
+        res.send(false);
+    }
+});
+
+router.get('/', function (req, res) {
+    res.send('Ceci est la route des parametres');
+});
+
+module.exports = router;

--- a/front-end/components/connectionForm.vue
+++ b/front-end/components/connectionForm.vue
@@ -55,7 +55,7 @@
             </nuxt-link>
             <br>
           </b-col>
-          <b-col cols="4" v-if="!hasToConfirmMail">           
+          <b-col cols="4" v-if="!hasToConfirmMail&&this.fc">           
             <nuxt-link :to="{
               name:'register',
               params:{ FCauthentified: true }
@@ -75,7 +75,8 @@ export default {
   data() {
       return {
           mail: '',
-          password: ''
+          password: '',
+          fc: false
       }
   },
   props: {
@@ -91,6 +92,23 @@ export default {
     if(this.hasToConfirmMail) {
       this.mail = this.$store.state.utilisateurCourant.mail
     }
+    const url = process.env.API_URL + '/parametres/fcactif'
+    console.info(url);
+    this.$axios.$get(url)
+    .then(response => {
+      if (response) 
+      {
+        console.log("France Connect Actif" + response)
+        this.fc = true
+      }
+      else
+      {
+        console.log("France Connect Inactif")
+        this.fc = false
+      }
+    }).catch(err => {
+      console.log(err)
+    })
   },
   methods: {
     submit: function() {

--- a/front-end/pages/index.vue
+++ b/front-end/pages/index.vue
@@ -21,12 +21,12 @@
           <connectionForm @submit="login"/>
         </b-col>
       </b-row>
-      <b-row class="text-center">
+      <b-row class="text-center" v-if="this.fc">
         <b-col cols="12">
           <span class="otherConnexion">Ou</span>
         </b-col>
       </b-row>
-      <b-row class="text-center" >
+      <b-row class="text-center" v-if="this.fc">
         <b-col cols="12">
           <b-img class="fcBtn" @click="connexionutilisateur()"  fluid  :src="require('assets/FCboutons-10.png')" border="0" style="size: 100%;" />
           <br>
@@ -46,7 +46,7 @@
         <b-col cols="12">
           <br>
           <span class="renvoiBasDePage">
-            (1) un maitre-nageur est un éducateur sportif professionnel détenteur d’une carte professionnelle, qualifié pour encadrer contre rémunération l’apprentissage de la natation( ex : BPJEPS AAn, DEJEPS Triathlon, Licence staps entrainement sportif « natation » ...
+            (1) un maitre-nageur est un éducateur sportif professionnel détenteur d’une carte professionnelle, qualifié pour encadrer contre rémunération l’apprentissage de la natation (ex : BPJEPS AAn, DEJEPS Triathlon, Licence staps entrainement sportif « natation » ...)
           </span>
             
         </b-col>
@@ -69,7 +69,8 @@ export default {
       b_MN: true,
       // Booleen agent de structure
       // V1 : On ne permet pas l'affichage du bouton Partenaire
-      b_AS: false
+      b_AS: false,
+      fc: false
     };
   },
 //
@@ -140,7 +141,24 @@ export default {
 //
   async mounted() {
     console.info("mounted home");
-    
+    const url = process.env.API_URL + '/parametres/fcactif'
+      console.info(url);
+      this.$axios.$get(url)
+      .then(response => {
+        if (response) 
+        {
+          console.debug("France Connect Actif" + response)
+          this.fc = true
+        }
+        else
+        {
+          console.debug("France Connect Inactif")
+          this.fc = false
+        }
+      }).catch(err => {
+        console.log(err)
+      })
+
   }
 };
 </script>


### PR DESCRIPTION
Ajout d'une route "parametres"
- Premier élément : fcactif : permet de savoir si la cle CLIENT_ID est renseignée : dans le cas contraire, impossible de se connecter avec du France connect, le bouton disparait.